### PR TITLE
Restrict Flavor Text processing to Equippable Items

### DIFF
--- a/PastLoot/Core/ItemInfo.lua
+++ b/PastLoot/Core/ItemInfo.lua
@@ -65,6 +65,12 @@ function PastLoot:InitItem(link)
 	item.link = link
 	item.id = GetItemInfoFromHyperlink(link)
 	item = fillItemInfo(item)
+	-- set some defaults since these are checked later if item flavor text isn't processed
+	item.isBloodforged = false
+	item.isHeroic = false
+	item.isMythic = false
+	item.isAscended = false
+	item.mythicLevel = 0 -- 0 means not a Mythic+ item
 	if item.equipSlot and item.equipSlot ~= "" then processItemFlavorText(item) end
 	return item
 end

--- a/PastLoot/Core/ItemInfo.lua
+++ b/PastLoot/Core/ItemInfo.lua
@@ -43,7 +43,7 @@ local function fillItemInfo(item)
 	return item
 end
 
-function PastLoot:FillContainerItemInfo(item,bag,slot)
+function PastLoot:FillContainerItemInfo(item, bag, slot)
 	local _, count, locked, _, readable, lootable, link = GetContainerItemInfo(bag, slot)
 	if item == nil and link ~= nil then item = self:InitItem(link) else return end
 
@@ -65,6 +65,6 @@ function PastLoot:InitItem(link)
 	item.link = link
 	item.id = GetItemInfoFromHyperlink(link)
 	item = fillItemInfo(item)
-	processItemFlavorText(item)
+	if item.equipSlot and item.equipSlot ~= "" then processItemFlavorText(item) end
 	return item
 end

--- a/README.md
+++ b/README.md
@@ -3,21 +3,6 @@ Code -> download zip -> Extract
 Move the **Pastloot** folder, that is in the same folder as this README, to your addons directory.
 
 
-**Warnings** 
+**Warnings**
 
-An empty rule will match and do whatever the setting is.  EG if you have an empty vendor rule as your first rule, it will vendor everything a vendor price.  I intend to change this behavior.
-
-Full usable but not yet ready for release
-
-```ini
-[Pre-release]
-review -> accept button
-macro to add/remove to default keep/vendor/delete rules
-implement destroy => on acquire, at bagspace threshold => report to default output
-default rules
-
-[Low Priority]
-warn when unvendorable item matches sell rule
-Module -> tsm prices
-Module -> tsm vs vendor
-```
+An empty rule will match and do whatever the setting is.  EG if you have an empty vendor rule as your first rule, it will vendor everything a vendor price.


### PR DESCRIPTION
This having to merge my own pull requests back is getting messy.

Flavor text is only processed for equippable items now.  Fixes a CoA bug where some items do not have Flavor Text set.  EG
![image](https://github.com/user-attachments/assets/2b1daae9-485d-462e-9969-97329b086fd9)
vs Elune
![image](https://github.com/user-attachments/assets/95ef3e54-1c33-4960-a7eb-bc21d4fb5dbe)
 (item is a mythic cache from classic raid)