### PR TITLE
Removed infinite loop (stack overflow) when creating delete confirmation

### DIFF
--- a/PastLoot/Core/PastLoot.lua
+++ b/PastLoot/Core/PastLoot.lua
@@ -772,7 +772,6 @@ function PastLoot:UpdateBags(...)
 				if dialog then
 					dialog.data = citem.clink
 				end
-				return
 			end
 		end
 	end


### PR DESCRIPTION
Added some checks and reworked the logic for delete confirmation boxes to remove a potential infinite loop when multiple items were looted at the same time which would trigger a delete confirmation, such as opening a fel enchanted warchest.